### PR TITLE
Add mapping for M1 Macs to use x64 targeted binary

### DIFF
--- a/src/sass
+++ b/src/sass
@@ -14,6 +14,7 @@ const knownWindowsPackages = {
 };
 
 const knownUnixlikePackages = {
+  "darwin arm64 LE": "sass-bin-darwin-64",
   "darwin x64 LE": "sass-bin-darwin-64",
   "linux ia32 LE": "sass-bin-linux-32",
   "linux x64 LE": "sass-bin-linux-64",


### PR DESCRIPTION
M1 Macs can run the x64 binary under Rosetta